### PR TITLE
Async job status API + client polling improvements

### DIFF
--- a/client/src/main/java/com/grid/client/ClientApp.java
+++ b/client/src/main/java/com/grid/client/ClientApp.java
@@ -6,7 +6,9 @@ import com.grid.common.model.SimulationJobTask;
 import com.grid.common.model.SimulationParams;
 import com.grid.common.model.SimulationResult;
 import com.grid.common.model.Weather;
-import com.grid.master.results.ResultCollector;
+//import com.grid.master.results.ResultCollector;
+import com.grid.common.dto.JobResult;
+import com.grid.common.dto.JobStatus;
 
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
@@ -17,35 +19,36 @@ import java.util.UUID;
 
 public class ClientApp {
 
-    // 6.3 – polling configuration
-    private static final long MAX_WAIT_MS = 60_000L;   // 1 minute max
-    private static final long POLL_INTERVAL_MS = 1_000L; // check every 1 second
 
     public static void main(String[] args) {
         final String registryHost = configLoader.get("registry.host");
         final int registryPort = configLoader.getInt("registry.port");
-        final String serviceName  = "MasterService"; // same as MasterNode binds
+        String masterServiceName = configLoader.get("master.service.name");
+        final long maxWaitMs = configLoader.getLong("client.max.wait.ms");
+        final long pollIntervalMs = configLoader.getLong("client.poll.interval.ms");
+
+
 
         System.out.printf("[Client] Connecting to RMI registry at %s:%d...%n",
                 registryHost, registryPort);
 
         try {
             Registry registry = LocateRegistry.getRegistry(registryHost, registryPort);
-            IMaster master = (IMaster) registry.lookup(serviceName);
+            IMaster master = (IMaster) registry.lookup(masterServiceName);
             System.out.println("The [Client] Successfully obtained IMaster stub from RMI registry.");
 
             // 6.2 – submit simulation parameters and get jobId
             UUID jobId = submitSimulation(master);
 
             SimulationResult finalResult =
-                    waitForFinalResult(master, jobId, MAX_WAIT_MS, POLL_INTERVAL_MS);
+                    waitForFinalResult(master, jobId, maxWaitMs, pollIntervalMs);
 
             displayFinalResult(jobId, finalResult);
 
 
         } catch (NotBoundException e) {
             System.err.printf("The [Client] Failed to connect to Master service:%n" +
-                    "\tNotBoundException - %s%n", serviceName);
+                    "\tNotBoundException - %s%n", masterServiceName);
             e.printStackTrace();
         } catch (RemoteException e) {
             System.err.printf("The [Client] RemoteException when connecting to registry: %s%n",
@@ -70,7 +73,7 @@ public class ClientApp {
 
         int iterations = readPositiveInt(scanner, "Iterations (e.g. 10_000): ");
         int cars       = readPositiveInt(scanner, "Cars count (e.g. 150): ");
-        int gridsize =readPositiveInt(scanner,"Grid Size");
+        int gridsize = readPositiveInt(scanner, "Grid Size: ");
         System.out.print("Use random seed? (y/n): ");
         String randomAnswer = scanner.nextLine().trim();
         boolean useRandomSeed = randomAnswer.equalsIgnoreCase("y")
@@ -90,17 +93,18 @@ public class ClientApp {
         // seed: we either generated it or validated user input
         // ---------------------------------------
 
-        // For now we fix weather + traffic lights. Later you can ask user too.
+        // For now we fix weather + traffic lights. Later you can ask user too. !!!!!!!!!!!
         SimulationParams params = new SimulationParams(
                 cars,
                 iterations,
-                Weather.SUNNY, // maybe default SUNNY for now
-                true,          // trafficLightsEnabled
+                Weather.SUNNY, // TEMP DEFAULT (user-select later)
+                true,           // TEMP DEFAULT (user-toggle later)
                 seed,
                 gridsize
         );
-
-        SimulationJobTask task = new SimulationJobTask(params);
+        // NOTE: SimulationJobTask is not used yet because IMaster currently accepts SimulationParams.
+        // When we expose a REST API / UI, we may submit a higher-level job object instead.
+        // SimulationJobTask task = new SimulationJobTask(params);
 
         System.out.println("[Client] Submitting simulation task to Master...");
         UUID jobId = master.submitTaskAsync(params);
@@ -108,11 +112,6 @@ public class ClientApp {
         System.out.printf("[Client] Simulation submitted successfully. jobId = %s%n", jobId);
         return jobId;
     }
-
-    /**
-     * 6.3 – Poll Master for the final result with timeout.
-     * Handles delays and temporary RemoteExceptions.
-     */
     private static SimulationResult waitForFinalResult(
             IMaster master,
             UUID jobId,
@@ -121,6 +120,8 @@ public class ClientApp {
     ) throws InterruptedException {
 
         long start = System.currentTimeMillis();
+        JobStatus lastStatus = null;
+        int consecutiveRemoteErrors = 0;
 
         while (true) {
             long elapsed = System.currentTimeMillis() - start;
@@ -131,26 +132,47 @@ public class ClientApp {
             }
 
             try {
-                ResultCollector.JobResult jobResult = (ResultCollector.JobResult )master.getFinalResult(jobId);
+                JobResult jobResult = master.getJobResult(jobId);
+                consecutiveRemoteErrors = 0;
 
-                if (jobResult == null) {
-                    System.out.println("[Client] Job not registered yet, waiting...");
-                } else {
-                    switch (jobResult.status()) {
-                        case RUNNING -> System.out.println("[Client] Job still running...");
-                        case COMPLETED -> {
-                            System.out.println("[Client] Job completed!");
-                            return jobResult.result();
-                        }
-                        case FAILED -> {
-                            System.err.println("[Client] Job failed: " + jobResult.status());
+                JobStatus status = (jobResult == null) ? JobStatus.PENDING : jobResult.status();
+
+                // Print only when status changes (less spam)
+                if (status != lastStatus) {
+                    System.out.println("[Client] Status = " + status + " (elapsed " + (elapsed / 1000) + "s)");
+                    lastStatus = status;
+                }
+                long lastProgressPrintMs = 0;
+                switch (status) {
+                    case COMPLETED -> {
+                        System.out.println("[Client] Job completed!");
+                        if (jobResult.result() == null) {
+                            System.err.println("[Client] Completed but result is null (check Master logs).");
                             return null;
+                        }
+                        return jobResult.result();
+                    }
+                    case FAILED -> {
+                        String msg = (jobResult.errorMessage() == null) ? "Unknown error" : jobResult.errorMessage();
+                        System.err.println("[Client] Job failed: " + msg);
+                        return null;
+                    }
+                    case RUNNING, PENDING -> {
+                        long now = System.currentTimeMillis();
+                        if (now - lastProgressPrintMs >= 5000) {
+                            System.out.println("[Client] Still " + status + "... (elapsed " + (elapsed / 1000) + "s)");
+                            lastProgressPrintMs = now;
                         }
                     }
                 }
 
             } catch (RemoteException e) {
-                System.err.println("[Client] Remote error while polling: " + e.getMessage());
+                consecutiveRemoteErrors++;
+                System.err.println("[Client] Remote error while polling (" + consecutiveRemoteErrors + "): " + e.getMessage());
+                if (consecutiveRemoteErrors >= 5) {
+                    System.err.println("[Client] Too many remote errors. Aborting.");
+                    return null;
+                }
             }
 
             Thread.sleep(pollIntervalMs);
@@ -174,13 +196,25 @@ public class ClientApp {
         }
 
         System.out.println("Total jams: " + result.getTotalJamsDetected());
-        System.out.println("Average speed: " + result.getAverageSpeed());
-        System.out.println("Congestion map: " + result.getCongestionMap());
+        System.out.printf("Average speed: %.2f%n", result.getAverageSpeed());
+        System.out.printf("Min speed observed: %.2f%n", result.getMinSpeedObserved());
+        System.out.printf("Max speed observed: %.2f%n", result.getMaxSpeedObserved());
+        System.out.printf("Accident probability: %.2f%%%n", result.getAccidentProbability() * 100);
+
+        System.out.println("Congestion map (road -> congestion%):");
+        if (result.getCongestionMap() == null || result.getCongestionMap().isEmpty()) {
+            System.out.println("  (empty)");
+        } else {
+            result.getCongestionMap().forEach((road, congestion) ->
+                    System.out.printf("  %s -> %.2f%%%n", road, congestion * 100)
+            );
+        }
     }
 
 
+
     private static int readPositiveInt(Scanner scanner, String label) {
-        final int MAX_VALUE = 1_000_000;
+        final int MAX_VALUE = configLoader.getInt("client.input.max.int");
 
         while (true) {
             System.out.print(label);

--- a/common/src/main/java/com/grid/common/Interfaces/IMaster.java
+++ b/common/src/main/java/com/grid/common/Interfaces/IMaster.java
@@ -1,5 +1,6 @@
 package com.grid.common.Interfaces;
 
+import com.grid.common.dto.JobResult;
 import com.grid.common.model.SimulationParams;
 
 import java.rmi.Remote;
@@ -16,6 +17,9 @@ public interface IMaster extends Remote {
 
     UUID submitTaskAsync(SimulationParams params) throws RemoteException;
 //    Result submitTaskSync(SimulationParams params) throws RemoteException;
+
+    // API for client ; depends only on common.
+    JobResult getJobResult(UUID jobId) throws RemoteException;
     /**
      * Return the final aggregated result for a task.
      */

--- a/common/src/main/java/com/grid/common/dto/JobResult.java
+++ b/common/src/main/java/com/grid/common/dto/JobResult.java
@@ -1,0 +1,10 @@
+package com.grid.common.dto;
+
+import com.grid.common.model.SimulationResult;
+import java.io.Serializable;
+
+public record JobResult(
+        JobStatus status,
+        SimulationResult result,
+        String errorMessage
+) implements Serializable {}

--- a/common/src/main/java/com/grid/common/dto/JobStatus.java
+++ b/common/src/main/java/com/grid/common/dto/JobStatus.java
@@ -1,0 +1,10 @@
+package com.grid.common.dto;
+
+import java.io.Serializable;
+
+public enum JobStatus implements Serializable {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/common/src/main/resources/config.properties
+++ b/common/src/main/resources/config.properties
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 
 
 # ==================================================
@@ -6,7 +5,17 @@
 # ==================================================
 registry.host=127.0.0.1
 registry.port=1099
+master.service.name=MasterService
 master.port=1100
+
+# ==================================================
+# Client polling
+# ==================================================
+client.max.wait.ms=60000
+client.poll.interval.ms=1000
+client.default.weather=SUNNY
+client.default.trafficLightsEnabled=true
+client.input.max.int=1000000
 
 # ==================================================
 # Worker Execution and Reliability Settings
@@ -17,7 +26,6 @@ heartbeat.interval=5000
 timeout.value=15000
 
 # ==================================================
-# Simulation Parameters
+# Simulation Parameters (optional defaults)
 # ==================================================
 simulation.iterations=1000000
->>>>>>> fa64ae810088e3cb8732f9786e5bc590684d6bb4

--- a/master/src/main/java/com/grid/master/MasterImpl.java
+++ b/master/src/main/java/com/grid/master/MasterImpl.java
@@ -6,6 +6,10 @@ import com.grid.common.Interfaces.IWorker;
 import com.grid.common.Interfaces.MasterCallback;
 import com.grid.common.model.SimulationChunkTask;
 import com.grid.common.model.SimulationParams;
+
+import com.grid.common.dto.JobResult;
+import com.grid.common.dto.JobStatus;
+
 import com.grid.master.assignment.WorkerAssignmentService;
 import com.grid.master.assignment.WorkerRegistry;
 import com.grid.master.results.ResultAggregator;
@@ -75,9 +79,54 @@ public class MasterImpl extends UnicastRemoteObject implements IMaster {
      * Client asks for the final result (async mode)
      * Master returns it if ready, or null if still running.
      */
+
     @Override
-    public ResultCollector.JobResult getFinalResult(UUID jobId) throws RemoteException {
+    public Record /* ResultCollector.JobResult */ getFinalResult(UUID jobId) throws RemoteException {
+        return collector.getFinalResult(jobId);     // must match IMaster signature exactly.
+    }
+    public ResultCollector.JobResult getFinalResultInternal(UUID jobId) {
         return collector.getFinalResult(jobId);
+    }
+    /**
+     * API for client depends only on common.
+     */
+    @Override
+    public JobResult getJobResult(UUID jobId) throws RemoteException {
+
+        ResultCollector.JobSnapshot snap;
+
+        // If jobId not registered, treat as PENDING or 'return FAILED'
+        try {
+            snap = collector.getSnapshot(jobId);
+        } catch (IllegalArgumentException e) {
+            return new JobResult(JobStatus.PENDING, null, null);
+        }
+
+        JobStatus mapped = mapStatus(snap.status());
+
+        // Only fetch result if completed
+        com.grid.common.model.SimulationResult result = null;
+        if (mapped == JobStatus.COMPLETED) {
+            // Now safe: final result exists
+            ResultCollector.JobResult jr = collector.getFinalResult(jobId);
+            result = jr.result();
+        }
+
+        // Use snapshot error message when FAILED
+        String error = (mapped == JobStatus.FAILED) ? snap.errorMessage() : null;
+
+        return new JobResult(mapped, result, error);
+    }
+    /**
+     * explicit mapping
+     */
+    private static JobStatus mapStatus(com.grid.master.results.JobStatus s) {
+        return switch (s) {
+            case PENDING -> JobStatus.PENDING;
+            case RUNNING -> JobStatus.RUNNING;
+            case COMPLETED -> JobStatus.COMPLETED;
+            case FAILED -> JobStatus.FAILED;
+        };
     }
 
 

--- a/master/src/main/java/com/grid/master/results/ResultCollector.java
+++ b/master/src/main/java/com/grid/master/results/ResultCollector.java
@@ -40,8 +40,6 @@ public class ResultCollector {
         }
         return res;
     }
-    */
-
     public JobResult getFinalResult(UUID jobId) {
         SimulationResult res = finalResults.get(jobId);
 
@@ -50,6 +48,30 @@ public class ResultCollector {
         }
         return new JobResult(JobStatus.COMPLETED, res);
     }
+*/
+public JobResult getFinalResult(UUID jobId) {
+    JobState state = jobs.get(jobId);
+
+    // If job not registered yet
+    if (state == null) {
+        return new JobResult(JobStatus.PENDING, null);
+    }
+
+    synchronized (state) {
+        // If failed, return FAILED immediately (no final result)
+        if (state.status == JobStatus.FAILED) {
+            return new JobResult(JobStatus.FAILED, null);
+        }
+    }
+
+    // Otherwise, check finalResults map
+    SimulationResult res = finalResults.get(jobId);
+
+    if (res == null) {
+        return new JobResult(JobStatus.RUNNING, null);
+    }
+    return new JobResult(JobStatus.COMPLETED, res);
+}
 
 
 

--- a/master/src/test/java/com/grid/master/MasterAsyncTest.java
+++ b/master/src/test/java/com/grid/master/MasterAsyncTest.java
@@ -112,7 +112,7 @@ public class MasterAsyncTest {
         ResultCollector.JobResult jr;
 
         while (true) {
-            jr = master.getFinalResult(jobId);
+            jr = master.getFinalResultInternal(jobId);
 
             if (jr.status() == JobStatus.COMPLETED) break;
 

--- a/worker/src/main/java/com/grid/worker/WorkerImplExampleForAsync.java
+++ b/worker/src/main/java/com/grid/worker/WorkerImplExampleForAsync.java
@@ -13,7 +13,7 @@ public class WorkerImplExampleForAsync extends UnicastRemoteObject implements IW
     public WorkerImplExampleForAsync() throws RemoteException {}
 
     @Override
-    public void executeAsync(UUID jobId, Task task, MasterCallback callback)
+    public void execute(UUID jobId, Task task, MasterCallback callback)
             throws RemoteException {
 
         new Thread(() -> {


### PR DESCRIPTION
- Added shared DTOs in common: JobStatus + JobResult
- Added a new remote API in IMaster: getJobResult(jobId) to return status/result/error
- Updated MasterImpl + ResultCollector to support reliable job status + error reporting
- Updated ClientApp to:
                  1. read runtime settings from config.properties (registry, service name, polling timeout/interval, input max)
                  2. poll using getJobResult() until COMPLETED/FAILED
                  3. print full simulation results (jams, avg/min/max speed, accident probability, congestion map)